### PR TITLE
Add IAM Role authentication with External ID support

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -14,10 +14,6 @@ textColor = "#c9d1d9"
 font = "sans serif"
 
 [client]
-showErrorDetails = true
-toolbarMode = "minimal"
-
-[global]
-developmentMode = false
+toolbarMode = "viewer"
 
 

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -16,4 +16,10 @@ font = "sans serif"
 [client]
 toolbarMode = "viewer"
 
+[global]
+developmentMode = false
+
+[runner]
+magicEnabled = false
+
 

--- a/src/cwt_ui/pages/1_Dashboard.py
+++ b/src/cwt_ui/pages/1_Dashboard.py
@@ -13,6 +13,18 @@ if APP_ENV == "production":
 else:
     DEBUG_MODE = True
 
+# Apply layout fixes inline
+st.markdown("""
+<style>
+    .main .block-container {
+        padding-left: 1rem;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+    }
+</style>
+""", unsafe_allow_html=True)
+
+# Debug utilities inline
 def debug_write(message: str):
     """Write debug message only if DEBUG_MODE is enabled"""
     if DEBUG_MODE:
@@ -132,6 +144,99 @@ def render(ec2_df: pd.DataFrame, s3_df: pd.DataFrame, cards, tables, formatters)
         debug_write(f"   - EC2 columns: {list(ec2_df.columns)}")
     if not s3_df.empty:
         debug_write(f"   - S3 columns: {list(s3_df.columns)}")
+
+    # Scan Controls Section
+    with st.container():
+        st.subheader("🔍 Scan Controls")
+        
+        col1, col2 = st.columns([3, 1])
+        with col1:
+            region = st.text_input(
+                "AWS Region",
+                value=st.session_state.get("region", os.getenv("AWS_DEFAULT_REGION", "us-east-1")),
+                help="Region to scan for resources",
+                key="dashboard_region"
+            )
+            st.session_state["region"] = region
+        
+        with col2:
+            if st.button("🚀 Run Live Scan", type="primary", use_container_width=True):
+                try:
+                    # Import scan function
+                    from cwt_ui.services import scans
+                    
+                    debug_write("🔍 **DEBUG:** Dashboard scan button clicked - starting scan...")
+                    
+                    # Prepare credentials if override is enabled
+                    creds = None
+                    auth_method = st.session_state.get("aws_auth_method", "user")
+                    if st.session_state.get("aws_override_enabled"):
+                        debug_write("🔍 **DEBUG:** Using session-scoped credentials")
+                        ak = st.session_state.get("aws_access_key_id", "").strip()
+                        sk = st.session_state.get("aws_secret_access_key", "").strip()
+                        rg = st.session_state.get("aws_default_region", "").strip()
+                        stoken = st.session_state.get("aws_session_token", "").strip()
+                        
+                        creds = {
+                            k: v
+                            for k, v in {
+                                "AWS_ACCESS_KEY_ID": ak,
+                                "AWS_SECRET_ACCESS_KEY": sk,
+                                "AWS_DEFAULT_REGION": rg or region,
+                                "AWS_SESSION_TOKEN": stoken,
+                            }.items()
+                            if v
+                        }
+                        
+                        # Add role-specific fields if using role auth
+                        if auth_method == "role":
+                            role_fields = {
+                                "AWS_ROLE_ARN": st.session_state.get("aws_role_arn", "").strip(),
+                                "AWS_EXTERNAL_ID": st.session_state.get("aws_external_id", "").strip(),
+                                "AWS_ROLE_SESSION_NAME": st.session_state.get("aws_role_session_name", "CloudWasteTracker").strip(),
+                            }
+                            creds.update({k: v for k, v in role_fields.items() if v})
+                            debug_write(f"   - Role ARN: {role_fields.get('AWS_ROLE_ARN', 'NOT SET')}")
+                            debug_write(f"   - External ID: {'SET' if role_fields.get('AWS_EXTERNAL_ID') else 'NOT SET'}")
+                        
+                        debug_write(f"   - Credentials prepared: {list(creds.keys()) if creds else 'NONE'}")
+                    else:
+                        debug_write("🔍 **DEBUG:** Using environment credentials")
+                    
+                    # Run the scan
+                    debug_write(f"   - Auth method: {auth_method}")
+                    ec2_df, s3_df = scans.run_all_scans(region=region, aws_credentials=creds, aws_auth_method=auth_method)
+                    debug_write("🔍 **DEBUG:** Dashboard scan completed")
+                    debug_write(f"   - EC2 results: {ec2_df.shape if not ec2_df.empty else 'EMPTY'}")
+                    debug_write(f"   - S3 results: {s3_df.shape if not s3_df.empty else 'EMPTY'}")
+                    
+                    # Update session state with results
+                    st.session_state["ec2_df"] = ec2_df
+                    st.session_state["s3_df"] = s3_df
+                    
+                    # Add timestamp
+                    import datetime as _dt
+                    scanned_at = _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+                    st.session_state["last_scan_at"] = scanned_at
+                    debug_write(f"🔍 **DEBUG:** Scan timestamp: {scanned_at}")
+                    
+                    # Add timestamp to dataframes
+                    if not ec2_df.empty:
+                        ec2_df["scanned_at"] = scanned_at
+                        st.session_state["ec2_df"] = ec2_df
+                    if not s3_df.empty:
+                        s3_df["scanned_at"] = scanned_at
+                        st.session_state["s3_df"] = s3_df
+                    
+                    st.success(f"✅ Scan completed at {scanned_at}")
+                    st.rerun()  # Refresh the page to show new data
+                    
+                except Exception as e:
+                    debug_write(f"🔍 **DEBUG:** Dashboard scan failed with error: {e}")
+                    st.error(f"Scan failed: {e}")
+        
+        st.caption(f"Last scan: {st.session_state.get('last_scan_at', 'Never')}")
+        st.divider()
 
     # KPIs
     idle_count, monthly_waste, cold_gb = _compute_summary(ec2_df, s3_df)

--- a/src/cwt_ui/pages/2_EC2.py
+++ b/src/cwt_ui/pages/2_EC2.py
@@ -13,6 +13,19 @@ if APP_ENV == "production":
 else:
     DEBUG_MODE = True
 
+
+# Apply layout fixes inline
+st.markdown("""
+<style>
+    .main .block-container {
+        padding-left: 1rem;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+    }
+</style>
+""", unsafe_allow_html=True)
+
+# Debug utilities inline
 def debug_write(message: str):
     """Write debug message only if DEBUG_MODE is enabled"""
     if DEBUG_MODE:

--- a/src/cwt_ui/pages/3_S3.py
+++ b/src/cwt_ui/pages/3_S3.py
@@ -13,6 +13,19 @@ if APP_ENV == "production":
 else:
     DEBUG_MODE = True
 
+
+# Apply layout fixes inline
+st.markdown("""
+<style>
+    .main .block-container {
+        padding-left: 1rem;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+    }
+</style>
+""", unsafe_allow_html=True)
+
+# Debug utilities inline
 def debug_write(message: str):
     """Write debug message only if DEBUG_MODE is enabled"""
     if DEBUG_MODE:

--- a/src/cwt_ui/pages/9_Settings.py
+++ b/src/cwt_ui/pages/9_Settings.py
@@ -16,10 +16,34 @@ if APP_ENV == "production":
 else:
     DEBUG_MODE = True
 
+
+# Apply layout fixes inline
+st.markdown("""
+<style>
+    .main .block-container {
+        padding-left: 1rem;
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+    }
+</style>
+""", unsafe_allow_html=True)
+
+# Debug utilities inline
 def debug_write(message: str):
     """Write debug message only if DEBUG_MODE is enabled"""
     if DEBUG_MODE:
         st.write(message)
+
+# Helper function for adding status column
+def _add_status(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return pd.DataFrame()
+    out = df.copy()
+    if "recommendation" in out.columns and "status" not in out.columns:
+        out["status"] = out["recommendation"].astype(str).str.upper().map(
+            lambda x: "🟢 OK" if x == "OK" else "🔴 Action"
+        )
+    return out
 
 # -------- storage locations (try project root, else user config dir) --------
 PROJECT_ROOT = Path(__file__).resolve().parents[3]  # repo root
@@ -152,8 +176,7 @@ def render() -> None:
     with st.expander("AWS Credentials (session only)", expanded=True):
         st.caption("Choose authentication method. These fields override environment variables only for this browser session. They are NOT saved to disk.")
 
-        # Initialize session keys
-        st.session_state.setdefault("aws_auth_method", "user")  # "user" or "role"
+        # Initialize session keys (except aws_auth_method which will be set by the radio widget)
         st.session_state.setdefault("aws_override_enabled", False)
         st.session_state.setdefault("aws_access_key_id", "")
         st.session_state.setdefault("aws_secret_access_key", "")
@@ -180,31 +203,72 @@ def render() -> None:
         # Show appropriate fields based on auth method
         if current_auth_method == "user":
             st.info("🔑 **IAM User Credentials** - Provide your AWS Access Key and Secret Key")
+            st.warning("⚠️ **Security Note**: These credentials are stored in session memory only and never saved to disk.")
             
             with st.form("aws_user_form", clear_on_submit=False):
-                ak = st.text_input("AWS_ACCESS_KEY_ID", value=st.session_state.get("aws_access_key_id", ""))
-                sk = st.text_input("AWS_SECRET_ACCESS_KEY", value=st.session_state.get("aws_secret_access_key", ""), type="password")
-                stoken = st.text_input("AWS_SESSION_TOKEN (optional)", value=st.session_state.get("aws_session_token", ""), type="password", 
+                ak = st.text_input("AWS_ACCESS_KEY_ID", value="", placeholder="Enter your AWS Access Key ID", type="password")
+                sk = st.text_input("AWS_SECRET_ACCESS_KEY", value="", placeholder="Enter your AWS Secret Access Key", type="password")
+                stoken = st.text_input("AWS_SESSION_TOKEN (optional)", value="", placeholder="Optional: For temporary credentials", type="password", 
                                      help="Optional: For temporary credentials")
-                rg = st.text_input("AWS_DEFAULT_REGION", value=st.session_state.get("aws_default_region", "us-east-1"))
+                rg = st.text_input("AWS_DEFAULT_REGION", value="us-east-1", placeholder="us-east-1")
                 
-                submitted = st.form_submit_button("Apply for this Session")
-                if submitted:
-                    # Store only in session_state; do not persist to disk
-                    st.session_state["aws_override_enabled"] = bool(use_override)
-                    st.session_state["aws_auth_method"] = "user"
-                    st.session_state["aws_access_key_id"] = ak.strip()
-                    st.session_state["aws_secret_access_key"] = sk.strip()
-                    st.session_state["aws_default_region"] = (rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")).strip()
-                    st.session_state["aws_session_token"] = stoken.strip()
+                col1, col2 = st.columns(2)
+                with col1:
+                    submitted = st.form_submit_button("Apply for this Session")
+                    if submitted:
+                        # Store only in session_state; do not persist to disk
+                        st.session_state["aws_override_enabled"] = bool(use_override)
+                        # Note: aws_auth_method is managed by the radio widget, don't set it here
+                        st.session_state["aws_access_key_id"] = ak.strip()
+                        st.session_state["aws_secret_access_key"] = sk.strip()
+                        st.session_state["aws_default_region"] = (rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")).strip()
+                        st.session_state["aws_session_token"] = stoken.strip()
+                        
+                        # Clear role fields when using user auth
+                        st.session_state["aws_role_arn"] = ""
+                        st.session_state["aws_external_id"] = ""
+                        st.session_state["aws_role_session_name"] = "CloudWasteTracker"
+                        
+                        st.session_state["region"] = st.session_state["aws_default_region"] or st.session_state.get("region", "us-east-1")
+                        st.success("Applied to current session. Use the sidebar 'Run Live Scan'.")
+                
+                with col2:
+                    # Test scan button - check if credentials are filled
+                    has_creds = bool(ak.strip() and sk.strip())
+                    test_scan = st.form_submit_button("🚀 Test Scan", disabled=not has_creds,
+                                                   help="Test scan with current credentials" if has_creds else "Enter credentials to enable")
                     
-                    # Clear role fields when using user auth
-                    st.session_state["aws_role_arn"] = ""
-                    st.session_state["aws_external_id"] = ""
-                    st.session_state["aws_role_session_name"] = "CloudWasteTracker"
-                    
-                    st.session_state["region"] = st.session_state["aws_default_region"] or st.session_state.get("region", "us-east-1")
-                    st.success("Applied to current session. Use the sidebar 'Run Live Scan'.")
+                    if test_scan and has_creds:
+                        try:
+                            from cwt_ui.services import scans as _scans
+                            
+                            # Prepare credentials
+                            creds = {
+                                "AWS_ACCESS_KEY_ID": ak.strip(),
+                                "AWS_SECRET_ACCESS_KEY": sk.strip(),
+                                "AWS_DEFAULT_REGION": (rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")).strip(),
+                                "AWS_SESSION_TOKEN": stoken.strip(),
+                            }
+                            
+                            region = st.session_state.get("region") or rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+                            ec2_df, s3_df = _scans.run_all_scans(region=region, aws_credentials=creds, aws_auth_method="user")
+                            
+                            st.session_state["ec2_df"] = _add_status(ec2_df)
+                            st.session_state["s3_df"] = _add_status(s3_df)
+                            
+                            import datetime as _dt
+                            scanned_at = _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+                            st.session_state["last_scan_at"] = scanned_at
+                            
+                            if not st.session_state["ec2_df"].empty:
+                                st.session_state["ec2_df"]["scanned_at"] = scanned_at
+                            if not st.session_state["s3_df"].empty:
+                                st.session_state["s3_df"]["scanned_at"] = scanned_at
+                            
+                            st.success(f"✅ Test scan completed at {scanned_at} using IAM User credentials.")
+                            
+                        except Exception as e:
+                            st.error(f"Test scan failed: {e}")
         
         else:
             st.info("🔒 **IAM Role Credentials** - More secure, uses temporary credentials via AssumeRole")
@@ -244,110 +308,117 @@ def render() -> None:
                 """)
             
             with st.form("aws_role_form", clear_on_submit=False):
-                role_arn = st.text_input("Role ARN", value=st.session_state.get("aws_role_arn", ""),
+                role_arn = st.text_input("Role ARN", value="", placeholder="arn:aws:iam::123456789012:role/CloudWasteTrackerRole",
                                        help="ARN of the IAM role to assume (e.g., arn:aws:iam::123456789012:role/CloudWasteTrackerRole)")
-                external_id = st.text_input("External ID", value=st.session_state.get("aws_external_id", ""),
+                external_id = st.text_input("External ID", value="", placeholder="Optional external ID for security",
                                           help="External ID for additional security (optional but recommended)")
-                session_name = st.text_input("Session Name", value=st.session_state.get("aws_role_session_name", "CloudWasteTracker"),
+                session_name = st.text_input("Session Name", value="CloudWasteTracker", placeholder="CloudWasteTracker",
                                            help="Name for this session (will appear in CloudTrail)")
-                rg = st.text_input("AWS_DEFAULT_REGION", value=st.session_state.get("aws_default_region", "us-east-1"))
+                rg = st.text_input("AWS_DEFAULT_REGION", value="us-east-1", placeholder="us-east-1")
                 
                 # Check if base credentials are available
                 env_ak = os.getenv("AWS_ACCESS_KEY_ID")
                 env_sk = os.getenv("AWS_SECRET_ACCESS_KEY")
                 
-                if env_ak and env_sk:
+                # Always use environment credentials if available, otherwise show manual input
+                if env_ak and env_sk and env_ak.strip() and env_sk.strip():
                     st.success("✅ **Base credentials detected** from environment variables")
                     st.caption("Using AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from environment")
-                    # Use environment credentials
-                    ak = env_ak
-                    sk = env_sk
+                    st.warning("⚠️ **Security Note**: Base credentials are loaded from environment variables, not displayed here for security.")
+                    # Use environment credentials (not displayed)
+                    ak = env_ak.strip()
+                    sk = env_sk.strip()
                 else:
                     st.warning("⚠️ **No base credentials found** in environment variables")
                     st.caption("Base credentials are required to assume the role")
-                    ak = st.text_input("Base AWS_ACCESS_KEY_ID", value=st.session_state.get("aws_access_key_id", ""),
+                    ak = st.text_input("Base AWS_ACCESS_KEY_ID", value="", placeholder="Enter base access key", type="password",
                                      help="Access key of user/service that can assume the role")
-                    sk = st.text_input("Base AWS_SECRET_ACCESS_KEY", value=st.session_state.get("aws_secret_access_key", ""), type="password",
+                    sk = st.text_input("Base AWS_SECRET_ACCESS_KEY", value="", placeholder="Enter base secret key", type="password",
                                      help="Secret key of user/service that can assume the role")
                 
-                submitted = st.form_submit_button("Apply for this Session")
-                if submitted:
-                    # Store only in session_state; do not persist to disk
-                    st.session_state["aws_override_enabled"] = bool(use_override)
-                    st.session_state["aws_auth_method"] = "role"
-                    st.session_state["aws_access_key_id"] = ak.strip()
-                    st.session_state["aws_secret_access_key"] = sk.strip()
-                    st.session_state["aws_default_region"] = (rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")).strip()
-                    st.session_state["aws_session_token"] = ""  # Role generates its own
-                    
-                    # Store role-specific fields
-                    st.session_state["aws_role_arn"] = role_arn.strip()
-                    st.session_state["aws_external_id"] = external_id.strip()
-                    st.session_state["aws_role_session_name"] = session_name.strip()
-                    
-                    st.session_state["region"] = st.session_state["aws_default_region"] or st.session_state.get("region", "us-east-1")
-                    
-                    # Show confirmation message
-                    if env_ak and env_sk:
-                        st.success("✅ Applied role configuration with environment base credentials. Use the sidebar 'Run Live Scan'.")
-                    else:
-                        st.success("✅ Applied role configuration with manual base credentials. Use the sidebar 'Run Live Scan'.")
-
-        # Optional immediate scan action (uses in-memory credentials)
-        def _add_status(df: pd.DataFrame) -> pd.DataFrame:
-            if df is None or df.empty:
-                return pd.DataFrame()
-            out = df.copy()
-            if "recommendation" in out.columns and "status" not in out.columns:
-                out["status"] = out["recommendation"].astype(str).str.upper().map(
-                    lambda x: "🟢 OK" if x == "OK" else "🔴 Action"
-                )
-            return out
-
-        c1, c2 = st.columns(2)
-        with c1:
-            if st.button("Run Scan Now"):
-                try:
-                    # Local import to avoid circulars
-                    from cwt_ui.services import scans as _scans
-                    creds = None
-                    if st.session_state.get("aws_override_enabled"):
-                        auth_method = st.session_state.get("aws_auth_method", "user")
-                        creds = {
-                            k: v for k, v in {
-                                "AWS_ACCESS_KEY_ID": st.session_state.get("aws_access_key_id", "").strip(),
-                                "AWS_SECRET_ACCESS_KEY": st.session_state.get("aws_secret_access_key", "").strip(),
-                                "AWS_DEFAULT_REGION": st.session_state.get("aws_default_region", "").strip(),
-                                "AWS_SESSION_TOKEN": st.session_state.get("aws_session_token", "").strip(),
-                            }.items() if v
-                        }
+                col1, col2 = st.columns(2)
+                with col1:
+                    submitted = st.form_submit_button("Apply for this Session")
+                    if submitted:
+                        # Store only in session_state; do not persist to disk
+                        st.session_state["aws_override_enabled"] = bool(use_override)
+                        # Note: aws_auth_method is managed by the radio widget, don't set it here
+                        st.session_state["aws_access_key_id"] = ak.strip()
+                        st.session_state["aws_secret_access_key"] = sk.strip()
+                        st.session_state["aws_default_region"] = (rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")).strip()
+                        st.session_state["aws_session_token"] = ""  # Role generates its own
                         
-                        # Add role-specific fields if using role auth
-                        if auth_method == "role":
-                            role_fields = {
-                                "AWS_ROLE_ARN": st.session_state.get("aws_role_arn", "").strip(),
-                                "AWS_EXTERNAL_ID": st.session_state.get("aws_external_id", "").strip(),
-                                "AWS_ROLE_SESSION_NAME": st.session_state.get("aws_role_session_name", "CloudWasteTracker").strip(),
-                            }
-                            creds.update({k: v for k, v in role_fields.items() if v})
+                        # Store role-specific fields
+                        st.session_state["aws_role_arn"] = role_arn.strip()
+                        st.session_state["aws_external_id"] = external_id.strip()
+                        st.session_state["aws_role_session_name"] = session_name.strip()
                         
-                        region = st.session_state.get("region") or st.session_state.get("aws_default_region") or os.getenv("AWS_DEFAULT_REGION", "us-east-1")
-                        ec2_df, s3_df = _scans.run_all_scans(region=region, aws_credentials=creds, aws_auth_method=auth_method)
-                    else:
-                        region = st.session_state.get("region") or st.session_state.get("aws_default_region") or os.getenv("AWS_DEFAULT_REGION", "us-east-1")
-                        ec2_df, s3_df = _scans.run_all_scans(region=region, aws_credentials=None)
-                    st.session_state["ec2_df"] = _add_status(ec2_df)
-                    st.session_state["s3_df"] = _add_status(s3_df)
-                    import datetime as _dt
-                    scanned_at = _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-                    st.session_state["last_scan_at"] = scanned_at
-                    if not st.session_state["ec2_df"].empty:
-                        st.session_state["ec2_df"]["scanned_at"] = scanned_at
-                    if not st.session_state["s3_df"].empty:
-                        st.session_state["s3_df"]["scanned_at"] = scanned_at
-                    st.success(f"Live scan completed at {scanned_at} (UTC) with current session credentials.")
-                except Exception as e:
-                    st.error(f"Scan failed: {e}")
+                        st.session_state["region"] = st.session_state["aws_default_region"] or st.session_state.get("region", "us-east-1")
+                        
+                        # Show confirmation message
+                        if env_ak and env_sk:
+                            st.success("✅ Applied role configuration with environment base credentials. Use the sidebar 'Run Live Scan'.")
+                        else:
+                            st.success("✅ Applied role configuration with manual base credentials. Use the sidebar 'Run Live Scan'.")
+                
+                with col2:
+                    # Test scan button for role - check if required fields are filled
+                    has_role_creds = bool(role_arn.strip() and ak and sk)
+                    test_scan = st.form_submit_button("🚀 Test Scan", disabled=not has_role_creds,
+                                                   help="Test role assumption and scan" if has_role_creds else "Enter role ARN and base credentials to enable")
+                    
+                    if test_scan and has_role_creds:
+                        try:
+                            from cwt_ui.services import scans as _scans
+                            
+                            # Prepare credentials for role assumption
+                            debug_write(f"🔍 **DEBUG:** IAM Role test scan - using environment credentials naturally")
+                            debug_write(f"🔍 **DEBUG:** Role ARN: {role_arn.strip()}")
+                            debug_write(f"🔍 **DEBUG:** External ID: {'SET' if external_id.strip() else 'NOT SET'}")
+                            
+                            # Store role configuration in session state for this test
+                            st.session_state["aws_role_arn"] = role_arn.strip()
+                            st.session_state["aws_external_id"] = external_id.strip()
+                            st.session_state["aws_role_session_name"] = session_name.strip()
+                            
+                            region = st.session_state.get("region") or rg or os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+                            
+                            # Use the same scan approach as Dashboard - scans service will read from session state
+                            ec2_df, s3_df = _scans.run_all_scans(region=region, aws_credentials=None, aws_auth_method="role")
+                            
+                            st.session_state["ec2_df"] = _add_status(ec2_df)
+                            st.session_state["s3_df"] = _add_status(s3_df)
+                            
+                            import datetime as _dt
+                            scanned_at = _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+                            st.session_state["last_scan_at"] = scanned_at
+                            
+                            if not st.session_state["ec2_df"].empty:
+                                st.session_state["ec2_df"]["scanned_at"] = scanned_at
+                            if not st.session_state["s3_df"].empty:
+                                st.session_state["s3_df"]["scanned_at"] = scanned_at
+                            
+                            st.success(f"✅ Test scan completed at {scanned_at} using IAM Role (AssumeRole) credentials.")
+                            
+                        except Exception as e:
+                            st.error(f"Test scan failed: {e}")
+
+
+        st.info("💡 **Tip:** Use the 'Test Scan' button within each form to verify your credentials work correctly.")
+        
+        # Clear session state button for debugging
+        if st.button("🗑️ Clear All Session Data", help="Clear all stored credentials and session data"):
+            keys_to_clear = [
+                "aws_access_key_id", "aws_secret_access_key", "aws_default_region", 
+                "aws_session_token", "aws_role_arn", "aws_external_id", 
+                "aws_role_session_name", "aws_auth_method", "aws_override_enabled",
+                "ec2_df", "s3_df", "last_scan_at"
+            ]
+            for key in keys_to_clear:
+                if key in st.session_state:
+                    del st.session_state[key]
+            st.success("Session data cleared! Please reconfigure your credentials.")
+            st.rerun()
 
     with st.expander("Stripe (Payments)", expanded=False):
         with st.form("stripe_form"):


### PR DESCRIPTION
This pull request adds support for authenticating with AWS IAM Roles using sts:AssumeRole and External ID, alongside the existing IAM User (Access Key + Secret) option.

### Changes included

- Added support for **Role ARN**, **External ID**, and **Session Name** in the Settings page  
- Integrated **STS AssumeRole** into the authentication flow  
- Improved security by enabling **temporary credentials** instead of relying only on static IAM User keys  
- Maintained **backward compatibility** with IAM User authentication  
